### PR TITLE
Refactor color assignments in Gtk handlers to use `GtkViewHandler.ToGtkColor'

### DIFF
--- a/src/Platform.Maui.Linux.Gtk4/Handlers/ListViewHandler.cs
+++ b/src/Platform.Maui.Linux.Gtk4/Handlers/ListViewHandler.cs
@@ -272,7 +272,7 @@ public class ListViewHandler : GtkViewHandler<ListView, Gtk.ScrolledWindow>
 		{
 			var c = cell.TextColor;
 			var css = Gtk.CssProvider.New();
-			css.LoadFromString($"label {{ color: rgba({(int)(c.Red*255)},{(int)(c.Green*255)},{(int)(c.Blue*255)},{c.Alpha}); }}");
+			css.LoadFromString($"label {{ color: {ToGtkColor(c)}; }}");
 			textLabel.GetStyleContext().AddProvider(css, Gtk.Constants.STYLE_PROVIDER_PRIORITY_APPLICATION);
 		}
 		row.Append(textLabel);
@@ -283,7 +283,7 @@ public class ListViewHandler : GtkViewHandler<ListView, Gtk.ScrolledWindow>
 			detailLabel.SetHalign(Gtk.Align.Start);
 			var detailCss = Gtk.CssProvider.New();
 			var dc = cell.DetailColor ?? Colors.Gray;
-			detailCss.LoadFromString($"label {{ font-size: 12px; color: rgba({(int)(dc.Red*255)},{(int)(dc.Green*255)},{(int)(dc.Blue*255)},{dc.Alpha}); }}");
+			detailCss.LoadFromString($"label {{ font-size: 12px; color: {ToGtkColor(dc)}; }}");
 			detailLabel.GetStyleContext().AddProvider(detailCss, Gtk.Constants.STYLE_PROVIDER_PRIORITY_APPLICATION);
 			row.Append(detailLabel);
 		}
@@ -351,7 +351,7 @@ public class ListViewHandler : GtkViewHandler<ListView, Gtk.ScrolledWindow>
 			{
 				var c = label.TextColor;
 				var css = Gtk.CssProvider.New();
-				css.LoadFromString($"label {{ color: rgba({(int)(c.Red*255)},{(int)(c.Green*255)},{(int)(c.Blue*255)},{c.Alpha}); }}");
+				css.LoadFromString($"label {{ color: {ToGtkColor(c)}; }}");
 				gtkLabel.GetStyleContext().AddProvider(css, Gtk.Constants.STYLE_PROVIDER_PRIORITY_APPLICATION);
 			}
 			if (label.FontAttributes.HasFlag(FontAttributes.Bold))

--- a/src/Platform.Maui.Linux.Gtk4/Handlers/SwipeViewHandler.cs
+++ b/src/Platform.Maui.Linux.Gtk4/Handlers/SwipeViewHandler.cs
@@ -214,7 +214,7 @@ public class SwipeViewHandler : GtkViewHandler<IView, Gtk.Box>
 			var bg = item.BackgroundColor ?? Colors.LightGray;
 			var cssProvider = Gtk.CssProvider.New();
 			cssProvider.LoadFromString(
-				$"button {{ background-image: none; background-color: rgba({(int)(bg.Red*255)},{(int)(bg.Green*255)},{(int)(bg.Blue*255)},{bg.Alpha}); color: white; border-radius: 0; border: none; }}");
+				$"button {{ background-image: none; background-color: {ToGtkColor(bg)}; color: white; border-radius: 0; border: none; }}");
 			btn.GetStyleContext().AddProvider(cssProvider, Gtk.Constants.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
 			var capturedItem = item;

--- a/src/Platform.Maui.Linux.Gtk4/Handlers/TableViewHandler.cs
+++ b/src/Platform.Maui.Linux.Gtk4/Handlers/TableViewHandler.cs
@@ -132,7 +132,7 @@ public class TableViewHandler : GtkViewHandler<TableView, Gtk.ScrolledWindow>
 		{
 			var c = cell.TextColor;
 			var css = Gtk.CssProvider.New();
-			css.LoadFromString($"label {{ color: rgba({(int)(c.Red*255)},{(int)(c.Green*255)},{(int)(c.Blue*255)},{c.Alpha}); }}");
+			css.LoadFromString($"label {{ color: {ToGtkColor(c)}; }}");
 			textLabel.GetStyleContext().AddProvider(css, Gtk.Constants.STYLE_PROVIDER_PRIORITY_APPLICATION);
 		}
 		box.Append(textLabel);
@@ -143,7 +143,7 @@ public class TableViewHandler : GtkViewHandler<TableView, Gtk.ScrolledWindow>
 			detailLabel.SetHalign(Gtk.Align.Start);
 			var dc = cell.DetailColor ?? Colors.Gray;
 			var css = Gtk.CssProvider.New();
-			css.LoadFromString($"label {{ font-size: 12px; color: rgba({(int)(dc.Red*255)},{(int)(dc.Green*255)},{(int)(dc.Blue*255)},{dc.Alpha}); }}");
+			css.LoadFromString($"label {{ font-size: 12px; color: {ToGtkColor(dc)}; }}");
 			detailLabel.GetStyleContext().AddProvider(css, Gtk.Constants.STYLE_PROVIDER_PRIORITY_APPLICATION);
 			box.Append(detailLabel);
 		}
@@ -252,7 +252,7 @@ public class TableViewHandler : GtkViewHandler<TableView, Gtk.ScrolledWindow>
 			{
 				var c = label.TextColor;
 				var css = Gtk.CssProvider.New();
-				css.LoadFromString($"label {{ color: rgba({(int)(c.Red*255)},{(int)(c.Green*255)},{(int)(c.Blue*255)},{c.Alpha}); }}");
+				css.LoadFromString($"label {{ color: {ToGtkColor(c)}; }}");
 				gtkLabel.GetStyleContext().AddProvider(css, Gtk.Constants.STYLE_PROVIDER_PRIORITY_APPLICATION);
 			}
 			if (label.FontAttributes.HasFlag(FontAttributes.Bold))


### PR DESCRIPTION
as of frequent warnings

(Platform.Maui.Linux.Gtk4.Sample:224027): Gtk-WARNING **: 15:46:04.087: Theme parser error: :1:41-42: Expected ')' at end of rgba()

use GtkViewHandler.ToGtkColor